### PR TITLE
define lower bound php-version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "homepage": "https://github.com/amphp/process",
     "description": "Asynchronous process manager",
     "require": {
+        "php": ">=5.4.0",
         "amphp/amp": "~0.16.0"
     },
     "license": "MIT",


### PR DESCRIPTION
as discussed for *nix systems 5.4 is enough for win 5.5+ is recommended