### PR TITLE
Better wording in error msg

### DIFF
--- a/Process.php
+++ b/Process.php
@@ -203,7 +203,7 @@ class Process {
         }
 
         if (!$this->proc) {
-            throw new \RuntimeException("Process was not yet launched");
+            throw new \RuntimeException("Process was not yet executed");
         }
 
         $this->writeBuf .= $str;


### PR DESCRIPTION
The new message uses the same term, we use in the api: `exec`