### PR TITLE
Allow closing stdin pipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.idea
 vendor
 composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 vendor
 composer.lock


### PR DESCRIPTION
Hello,

The current implementation seems solid (I really like that Amp ecosystem!), but the API is somewhat closed and limited.

I personally need to close the stdin pipe after having sent the data to the spawned process, that waits for stdin to be closed before processing.

I've made a rapid and "dirty" patch to the library to add `Process#closeStdin()` because I need it right now.

Feel free to comment, merge, ask for more commits, cleaner implementation or simply close the PR without explanation :)

Example :

```php
Amp\run(function() {
    $process = new Amp\Process('cat');
    $execution = $process->exec();
    
    yield $process->write("Hi!\n");
    
    $process->closeStdin(); // `cat` waits indefinitely without that
    
    yield $execution;
});
```