### PR TITLE
Process leaks its IO streams

### DIFF
--- a/lib/Process.php
+++ b/lib/Process.php
@@ -238,6 +238,21 @@ class Process {
 
             $deferred->resolve($code);
         });
+        
+        // Close all streams when process is closed
+        $deferred->promise()->onResolve(function() {
+            if ($this->stdin !== null) {
+                $this->stdin->close();
+            }
+
+            if ($this->stdout !== null) {
+                $this->stdout->close();
+            }
+
+            if ($this->stderr !== null) {
+                $this->stderr->close();
+            }
+        });
 
         Loop::unreference($this->watcher);
     }


### PR DESCRIPTION
If streams are not closed when child process is finished, the IO streams leak in the loop and may result in infinitely leaked FDs when loop is reset