### PR TITLE
Changed Windows socket timeout from 1s -> 30s

### DIFF
--- a/lib/Internal/Windows/SocketConnector.php
+++ b/lib/Internal/Windows/SocketConnector.php
@@ -15,7 +15,7 @@ use Amp\Process\ProcessException;
 final class SocketConnector {
     const SERVER_SOCKET_URI = 'tcp://127.0.0.1:0';
     const SECURITY_TOKEN_SIZE = 16;
-    const CONNECT_TIMEOUT = 1000;
+    const CONNECT_TIMEOUT = 30000;
 
     /** @var resource */
     private $server;


### PR DESCRIPTION
One second is an insanely short timeout for a socket to respond. Many web services delivering heavy web applications easily trip this timeout during normal use. See #21.