### PR TITLE
Use correct arg escape logic on windows

### DIFF
--- a/lib/Process.php
+++ b/lib/Process.php
@@ -46,7 +46,7 @@ final class Process
     public function __construct($command, string $cwd = null, array $env = [], array $options = [])
     {
         $command = \is_array($command)
-            ? \implode(" ", \array_map("escapeshellarg", $command))
+            ? \implode(" ", \array_map(__NAMESPACE__ . "\\escape_arg", $command))
             : (string) $command;
 
         $cwd = $cwd ?? "";
@@ -68,7 +68,7 @@ final class Process
         $this->processRunner = Loop::getState(self::class);
 
         if ($this->processRunner === null) {
-            $this->processRunner = \strncasecmp(\PHP_OS, "WIN", 3) === 0
+            $this->processRunner = IS_WINDOWS
                 ? new WindowsProcessRunner
                 : new PosixProcessRunner;
 

--- a/lib/constants.php
+++ b/lib/constants.php
@@ -3,3 +3,18 @@
 namespace Amp\Process;
 
 const BIN_DIR = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'bin';
+const IS_WINDOWS = (PHP_OS & "\xDF\xDF\xDF") === 'WIN';
+
+if (IS_WINDOWS) {
+    function escape_arg($arg)
+    {
+        return '"' . \preg_replace_callback('(\\\\*("|$))', function ($m) {
+            return \str_repeat('\\', \strlen($m[0])) . $m[0];
+        }, $arg) . '"';
+    }
+} else {
+    function escape_arg($arg)
+    {
+        return \escapeshellarg($arg);
+    }
+}


### PR DESCRIPTION
Escape arguments according to https://docs.microsoft.com/en-us/previous-versions//17w5ykft(v=vs.85)

This mechanism works when passed directly to `CreateProcess()` as is done by the process wrapper. It does _not_ work for `proc_open()` unless the `bypass_shell` option is used.