### PR TITLE
RFC Check for constant existence before declaring

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2,8 +2,12 @@
 
 namespace Amp\Process;
 
-const BIN_DIR = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'bin';
-const IS_WINDOWS = (PHP_OS & "\xDF\xDF\xDF") === 'WIN';
+if (!defined('BIN_DIR')) {
+    define('BIN_DIR', __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'bin');
+}
+if (!defined('IS_WINDOWS')) {
+    define('IS_WINDOWS', (PHP_OS & "\xDF\xDF\xDF") === 'WIN');
+}
 
 if (IS_WINDOWS) {
     /**


### PR DESCRIPTION
I use an tool which requires the composer `autoloader.php` in order to use the class map.

When this tool is used with the library it issues a warning as these constants are then redefined.

This PR checks for the existence of the constants before defining them.