### PR TITLE
Added guard to ensure socket is still open before closing

### DIFF
--- a/lib/Internal/Windows/SocketConnector.php
+++ b/lib/Internal/Windows/SocketConnector.php
@@ -310,7 +310,10 @@ final class SocketConnector
 
         // Explicitly \fclose() sockets, as resource streams shut only one side down.
         foreach ($handle->sockets as $sock) {
-            @\fclose($sock);
+            // Ensure socket is still open before attempting to close.
+            if (is_resource($sock)) {
+                @\fclose($sock);
+            }
         }
     }
 


### PR DESCRIPTION
This is required to ensure no TypeError is thrown by attempting to close
a socket that is already closed, since PHP 8 where warnings were
promoted to errors.