### PR TITLE
Bugfix | Install specific php version for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - IF %PHP%==1 sc config wuauserv start= auto
   - IF %PHP%==1 net start wuauserv
   - IF %PHP%==1 cinst -y OpenSSL.Light
-  - IF %PHP%==1 cinst -y php
+  - IF %PHP%==1 cinst -y php -version 7.4.16
   - cd c:\tools\php74
   - IF %PHP%==1 copy php.ini-production php.ini /Y
   - IF %PHP%==1 echo date.timezone="UTC" >> php.ini

--- a/lib/Internal/Windows/Runner.php
+++ b/lib/Internal/Windows/Runner.php
@@ -218,10 +218,14 @@ final class Runner implements ProcessRunner
         $handle->stderr->close();
 
         foreach ($handle->sockets as $socket) {
-            @\fclose($socket);
+            if (\is_resource($socket)) {
+                @\fclose($socket);
+            }
         }
 
-        @\fclose($handle->wrapperStderrPipe);
+        if (\is_resource($handle->wrapperStderrPipe)) {
+            @\fclose($handle->wrapperStderrPipe);
+        }
 
         if (\is_resource($handle->proc)) {
             \proc_close($handle->proc);

--- a/test/ProcessTest.php
+++ b/test/ProcessTest.php
@@ -372,7 +372,7 @@ class ProcessTest extends TestCase
             $conn = \stream_socket_accept($socket);
             $this->assertSame('start', \fread($conn, 5));
             $process->kill();
-            $this->assertEmpty(\fread($conn, 3));
+            $this->assertSame('', \fread($conn, 3));
         });
     }
 

--- a/test/ProcessTest.php
+++ b/test/ProcessTest.php
@@ -369,7 +369,10 @@ class ProcessTest extends TestCase
             $socket = \stream_socket_server("tcp://0.0.0.0:10000", $errno, $errstr);
             $this->assertNotFalse($socket);
             $process = new Process(["php", __DIR__ . "/bin/socket-worker.php"]);
+            $start = microtime(true);
             yield $process->start();
+            $end = microtime(true) - $start;
+            var_dump($end);
             $conn = \stream_socket_accept($socket);
             $this->assertSame('start', \fread($conn, 5));
             $process->kill();

--- a/test/ProcessTest.php
+++ b/test/ProcessTest.php
@@ -372,11 +372,11 @@ class ProcessTest extends TestCase
             yield $process->start();
             $conn = \stream_socket_accept($socket);
             $this->assertSame('start', \fread($conn, 5));
+            $process->kill();
 
             var_dump(yield ByteStream\buffer($process->getStdout()));
             var_dump(yield ByteStream\buffer($process->getStderr()));
 
-            $process->kill();
             $this->assertSame('', \fread($conn, 3));
         });
     }

--- a/test/ProcessTest.php
+++ b/test/ProcessTest.php
@@ -369,16 +369,10 @@ class ProcessTest extends TestCase
             $socket = \stream_socket_server("tcp://0.0.0.0:10000", $errno, $errstr);
             $this->assertNotFalse($socket);
             $process = new Process(["php", __DIR__ . "/bin/socket-worker.php"]);
-            $start = microtime(true);
             yield $process->start();
             $conn = \stream_socket_accept($socket);
             $this->assertSame('start', \fread($conn, 5));
             $process->kill();
-            $end = microtime(true) - $start;
-            var_dump($end);
-            var_dump(yield ByteStream\buffer($process->getStdout()));
-            var_dump(yield ByteStream\buffer($process->getStderr()));
-
             $this->assertSame('', \fread($conn, 3));
         });
     }

--- a/test/ProcessTest.php
+++ b/test/ProcessTest.php
@@ -5,6 +5,7 @@ namespace Amp\Process\Test;
 use Amp\ByteStream\Message;
 use Amp\Delayed;
 use Amp\Loop;
+use Amp\ByteStream;
 use Amp\Process\Internal\ProcessStatus;
 use Amp\Process\Process;
 use Amp\Process\ProcessInputStream;
@@ -371,12 +372,10 @@ class ProcessTest extends TestCase
             yield $process->start();
             $conn = \stream_socket_accept($socket);
             $this->assertSame('start', \fread($conn, 5));
-            $process->getStderr()->read()->onResolve(function() {
-                var_dump(func_get_args());
-            });
-            $process->getStdout()->read()->onResolve(function() {
-                var_dump(func_get_args());
-            });
+
+            var_dump(yield ByteStream\buffer($process->getStdout()));
+            var_dump(yield ByteStream\buffer($process->getStderr()));
+
             $process->kill();
             $this->assertSame('', \fread($conn, 3));
         });

--- a/test/ProcessTest.php
+++ b/test/ProcessTest.php
@@ -371,12 +371,11 @@ class ProcessTest extends TestCase
             $process = new Process(["php", __DIR__ . "/bin/socket-worker.php"]);
             $start = microtime(true);
             yield $process->start();
-            $end = microtime(true) - $start;
-            var_dump($end);
             $conn = \stream_socket_accept($socket);
             $this->assertSame('start', \fread($conn, 5));
             $process->kill();
-
+            $end = microtime(true) - $start;
+            var_dump($end);
             var_dump(yield ByteStream\buffer($process->getStdout()));
             var_dump(yield ByteStream\buffer($process->getStderr()));
 

--- a/test/ProcessTest.php
+++ b/test/ProcessTest.php
@@ -362,7 +362,7 @@ class ProcessTest extends TestCase
         });
     }
 
-    public function testKillPHPImmediatly()
+    public function testKillPHPImmediately()
     {
         Loop::run(function () {
             $socket = \stream_socket_server("tcp://0.0.0.0:10000", $errno, $errstr);
@@ -371,6 +371,12 @@ class ProcessTest extends TestCase
             yield $process->start();
             $conn = \stream_socket_accept($socket);
             $this->assertSame('start', \fread($conn, 5));
+            $process->getStderr()->read()->onResolve(function() {
+                var_dump(func_get_args());
+            });
+            $process->getStdout()->read()->onResolve(function() {
+                var_dump(func_get_args());
+            });
             $process->kill();
             $this->assertSame('', \fread($conn, 3));
         });

--- a/test/bin/socket-worker.php
+++ b/test/bin/socket-worker.php
@@ -1,5 +1,6 @@
 <?php
 $socket = \fsockopen('127.0.0.1', 10000);
 \fwrite($socket, 'start');
-\sleep(2);
+$result = \sleep(2);
+var_dump($result);
 \fwrite($socket, 'end');

--- a/test/bin/socket-worker.php
+++ b/test/bin/socket-worker.php
@@ -1,5 +1,5 @@
 <?php
 $socket = \fsockopen('127.0.0.1', 10000);
 \fwrite($socket, 'start');
-\sleep(2);
+\sleep(10);
 \fwrite($socket, 'end');

--- a/test/bin/socket-worker.php
+++ b/test/bin/socket-worker.php
@@ -2,5 +2,4 @@
 $socket = \fsockopen('127.0.0.1', 10000);
 \fwrite($socket, 'start');
 $result = \sleep(2);
-var_dump($result);
 \fwrite($socket, 'end');

--- a/test/bin/socket-worker.php
+++ b/test/bin/socket-worker.php
@@ -1,5 +1,5 @@
 <?php
 $socket = \fsockopen('127.0.0.1', 10000);
 \fwrite($socket, 'start');
-$result = \sleep(2);
+\sleep(2);
 \fwrite($socket, 'end');


### PR DESCRIPTION
Install php 7.4 for appveyor to have tests passed. Required for any other PR's