### PR TITLE
Update revolt to ^0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "amphp/amp": "^3",
         "amphp/byte-stream": "^2",
         "amphp/sync": "^2",
-        "revolt/event-loop": "^0.1.1"
+        "revolt/event-loop": "^0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
See amphp/sync#20

Does not currently install due to `"minimum-stability": "beta"` giving `amphp/sync v2.0.0-beta.1` rather than `amphp/sync dev-master` - will solve itself on the next the next beta tag of amphp/sync, or if a project uses `"minimum-stability": "dev"`.