### PR TITLE
fix(posix): posix_kill crashes/kills other programs on null

### DIFF
--- a/lib/Internal/Posix/Runner.php
+++ b/lib/Internal/Posix/Runner.php
@@ -194,7 +194,7 @@ final class Runner implements ProcessRunner
                 return;
             }
             // ignore errors because process not always detached
-            @\posix_kill($pid, 9);
+            self::tryPosixKill($pid, 9);
         });
 
         if ($handle->status < ProcessStatus::ENDED) {
@@ -213,8 +213,15 @@ final class Runner implements ProcessRunner
                 return;
             }
 
-            @\posix_kill($pid, $signo);
+            self::tryPosixKill($pid, $signo);
         });
+    }
+
+    public static function tryPosixKill($pid, int $signo)
+    {
+        if ($pid !== null) {
+            @\posix_kill($pid, $signo);
+        }
     }
 
     /** @inheritdoc */

--- a/lib/Internal/Posix/Runner.php
+++ b/lib/Internal/Posix/Runner.php
@@ -217,7 +217,7 @@ final class Runner implements ProcessRunner
         });
     }
 
-    public static function tryPosixKill($pid, int $signo)
+    private static function tryPosixKill($pid, int $signo)
     {
         if ($pid !== null) {
             @\posix_kill($pid, $signo);


### PR DESCRIPTION
When `$pid` in `posix_kill($pid, $signo)` is `null` it kills other programs like Firefox, Terminal, even Gnome Shell. This patch adds a null check to avoid this.

Discovered via phpactor in Sublime Text: removing several folders in quick succession causes `posix_kill` to be called with `null`, for whatever reason, which causes a bunch of programs to crash.

See https://github.com/phpactor/phpactor/issues/2516